### PR TITLE
Broken NEXT operator after Otrs 5

### DIFF
--- a/Kernel/System/CloneDB/Backend.pm
+++ b/Kernel/System/CloneDB/Backend.pm
@@ -444,7 +444,6 @@ sub PopulateTargetStructuresPost {
     $Self->PrintWithTime("Creating structures in target database (phase 2/2)");
 
     for my $Statement ( @{ $Self->{SQLPost} } ) {
-        next STATEMENT if $Statement =~ m{^INSERT}smxi;
         my $Result = $Param{TargetDBObject}->Do( SQL => $Statement );
         print '.';
         if ( !$Result ) {


### PR DESCRIPTION
Hey guys!

After migration to Otrs ver.5 thre was an issue, that Insert statements did not execute in PopulateTargetStructuresPost() method due to extra line, containing a filter for Insert statements ( Supposedly copypasted from PopulateTargetStructuresPre method )

Please take a look, whether this fix is working fine on all databases ( Have tested it on MySQL -> OracleDB )
