### PR TITLE
Avoid logging too much data

### DIFF
--- a/Kernel/System/CloneDB/Driver/Base.pm
+++ b/Kernel/System/CloneDB/Driver/Base.pm
@@ -304,7 +304,7 @@ sub DataTransfer {
                     my $ReplacementMessage =
                         "On table: $Table, column: $Column, id: $Row[0] - exists an invalid utf8 value. \n"
                         .
-                        " $ColumnValue is replaced by : $TmpResult . \n\n";
+                        "and we have replaced it with xFFFD\n\n";
 
                     # open log file
                     if ( !open $FH, '>>', $LogFile ) {    ## no critic


### PR DESCRIPTION
When invalid utf8 values are replaced with the replacement character the data record could be huge (like the content of a 1MB email) thus it is not appropriate for logging purposes.